### PR TITLE
Enhance parser-lalr to the point of parsing/printing sexps for basic fns

### DIFF
--- a/parser-lalr-main.c
+++ b/parser-lalr-main.c
@@ -10,6 +10,7 @@ extern int yydebug;
 
 struct node {
   struct node *next;
+  struct node *prev;
   char const *name;
   int n_elems;
   struct node *elems[];
@@ -21,19 +22,65 @@ int n_nodes;
 struct node *mk_node(char const *name, int n, ...) {
   va_list ap;
   int i = 0;
-  va_start(ap, n);
-  printf("making node: %s\n", name);
-  struct node *nd = (struct node *)malloc(sizeof(struct node)
-					  + n * sizeof(struct node *));
+  unsigned sz = sizeof(struct node) + (n * sizeof(struct node *));
+  struct node *nn, *nd = (struct node *)malloc(sz);
+
+  printf("# New %d-ary node: %s = %p\n", n, name, nd);
+
+  nd->prev = NULL;
   nd->next = nodes;
+  if (nodes) {
+    nodes->prev = nd;
+  }
   nodes = nd;
+
   nd->name = name;
   nd->n_elems = n;
+
+  va_start(ap, n);
   while (i < n) {
-    nd->elems[i++] = va_arg(ap, struct node *);
+    nn = va_arg(ap, struct node *);
+    printf("#   arg[%d]: %p\n", i, nn);
+    printf("#            (%s ...)\n", nn->name);
+    nd->elems[i++] = nn;
   }
   va_end(ap);
   n_nodes++;
+  return nd;
+}
+
+struct node *ext_node(struct node *nd, int n, ...) {
+  va_list ap;
+  int i = 0, c = nd->n_elems + n;
+  unsigned sz = sizeof(struct node) + (c * sizeof(struct node *));
+  struct node *nn;
+
+  printf("# Extending %d-ary node by %d nodes: %s = %p",
+         nd->n_elems, c, nd->name, nd);
+
+  if (nd->next) {
+    nd->next->prev = nd->prev;
+  }
+  if (nd->prev) {
+    nd->prev->next = nd->next;
+  }
+  nd = realloc(nd, sz);
+  nd->prev = NULL;
+  nd->next = nodes;
+  nodes->prev = nd;
+  nodes = nd;
+
+  printf(" ==> %p\n", nd);
+
+  va_start(ap, n);
+  while (i < n) {
+    nn = va_arg(ap, struct node *);
+    printf("#   arg[%d]: %p\n", i, nn);
+    printf("#            (%s ...)\n", nn->name);
+    nd->elems[nd->n_elems++] = nn;
+    ++i;
+  }
+  va_end(ap);
   return nd;
 }
 
@@ -68,6 +115,7 @@ int main() {
     nodes = tmp->next;
     free(tmp);
   }
+  return ret;
 }
 
 void yyerror(char const *s) {


### PR DESCRIPTION
```
$ echo 'fn foo() { {10} - 1 }' | ./parser-lalr | grep -v '^#'
--- PARSE COMPLETE: ret:0, n_nodes:9 ---
(crate
    (mod-items
        (fn
            (stmts
                (block
                    (stmts
                        (lit-int
                        )
                    )
                )
                (-
                    (lit-int
                    )
                )
            )
        )
    )
)
```
