### PR TITLE
Update lexer to be more JFlex friendly

### DIFF
--- a/lexer.l
+++ b/lexer.l
@@ -38,7 +38,7 @@ usuf (u8|u16|u32|u64|u)
 
 [ \n\t\r]             { }
 
-\/\/(\/|!)            { BEGIN(doc_line); yymore(); }
+\/\/(\/|\!)           { BEGIN(doc_line); yymore(); }
 <doc_line>\n          { BEGIN(INITIAL); yyleng--; yytext[yyleng] = 0; return DOC_COMMENT; }
 <doc_line>[^\n]*      { yymore(); }
 
@@ -133,12 +133,12 @@ while    { return WHILE; }
 \]     { return ']'; }
 @      { return '@'; }
 #      { BEGIN(pound); }
-<pound>! { BEGIN(shebang_or_attr); }
+<pound>\! { BEGIN(shebang_or_attr); }
 <shebang_or_attr>\[ { BEGIN(INITIAL); yyless(0); return SHEBANG; }
-<shebang_or_attr>[^[\n]*\n  { BEGIN(INITIAL); }
+<shebang_or_attr>[^\[\n]*\n  { BEGIN(INITIAL); }
 <pound>. { BEGIN(INITIAL); yyless(0); return '#'; }
 
-~      { return '~'; }
+\~     { return '~'; }
 ::     { return MOD_SEP; }
 :      { return ':'; }
 \$     { return '$'; }
@@ -146,8 +146,8 @@ while    { return WHILE; }
 ==    { return EQEQ; }
 =>    { return FAT_ARROW; }
 =     { return '='; }
-!=    { return NE; }
-!     { return '!'; }
+\!=   { return NE; }
+\!    { return '!'; }
 \<=   { return LE; }
 \<\<  { return SHL; }
 \<\<= { return BINOPEQ; }
@@ -248,7 +248,7 @@ r/#             {
 
 -\>  { return RARROW; }
 -    { return '-'; }
--=   { return BINOPEQ; };
+-=   { return BINOPEQ; }
 &&   { return ANDAND; }
 &    { return '&'; }
 &=   { return BINOPEQ; }


### PR DESCRIPTION
I've tried to use the lexer with JFlex (Java version of Flex). I've made some changes to it, and after doing a diff with the old one on the generated code, there is no differences except for the rogue semicolon on the `--=` rule.

I still have problems with the `isuf` and `usuf` rules (that syntax is not valid in JFlex), but changing them to be `isuf=i8|i16|i32|i64|i` doesn't generate the same code, although after testing it looks like it's working.

If this can be accepted and somebody can help with the rest of my issues, that will be great :)
