### PR TITLE
fix potential realloc bug in ext_node

### DIFF
--- a/parser-lalr-main.c
+++ b/parser-lalr-main.c
@@ -114,6 +114,9 @@ struct node *ext_node(struct node *nd, int n, ...) {
   if (nd->prev) {
     nd->prev->next = nd->next;
   }
+  if (nodes == nd) {
+    nodes = nd->next;
+  }
   nd = realloc(nd, sz);
   nd->prev = NULL;
   nd->next = nodes;


### PR DESCRIPTION
I copied some of your code for a hobby project, and this bug showed up.

Note that I was unable to test this fix on your project (compiling rlex.rs failed for me using rustc 1.0.0 on mac).
